### PR TITLE
Update dependency due to uplift spring boot from 2.7.8 to 4.0.6 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
     <parent>
         <groupId>com.github.eiffel-community</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>2.0.19</version>
+        <version>2.0.20</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
-    <version>2.4.4</version>
+    <version>2.4.6</version>
     <packaging>jar</packaging>
     <properties>
         <eclipse.jgit.version>5.0.1.201806211838-r</eclipse.jgit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,9 @@
             <version>1.5.0</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.hk2.external</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -117,9 +118,9 @@
             <version>2.3.1</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>3.0.0</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.0</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.eiffel-community</groupId>
         <artifactId>eiffel-remrem-parent</artifactId>
-        <version>2.0.20</version>
+        <version>2.0.21</version>
     </parent>
     <artifactId>eiffel-remrem-semantics</artifactId>
     <version>2.4.6</version>

--- a/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
+++ b/src/main/java/com/ericsson/eiffel/remrem/semantics/SemanticsService.java
@@ -61,8 +61,8 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Named;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Named;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/src/test/java/com/ericsson/eiffel/remrem/semantics/FakeConfig.java
+++ b/src/test/java/com/ericsson/eiffel/remrem/semantics/FakeConfig.java
@@ -14,7 +14,7 @@
 */
 package com.ericsson.eiffel.remrem.semantics;
 
-import javax.inject.Named;
+import jakarta.inject.Named;
 
 @Named public class FakeConfig {
 


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues

Updates eiffel-remrem-semantics dependencies to be compatible with the Spring Boot 4.0.3 upgrade.

### Description of the Change

**Update dependencies for Spring Boot 2.7.8 → 4.0.6 uplift**

**Changes:**

Bumped eiffel-remrem-parent from 2.0.20 → 2.0.21

Bumped artifact version from 2.4.4 → 2.4.6

Migrated javax.inject → jakarta.inject-api:2.0.1 (javax → jakarta namespace)

Migrated javax.annotation-api:1.3.2 → jakarta.annotation-api:3.0.0 (javax → jakarta namespace)

Updated Java imports in SemanticsService.java and FakeConfig.java from javax.annotation.PostConstruct / javax.inject.Named to their jakarta.* equivalents

**Why**:
Spring Boot 3+ / 4+ requires the Jakarta EE namespace (jakarta.*) instead of the legacy Java EE namespace (javax.*). These changes align the semantics module with the parent project's Spring Boot 4.0.3 uplift.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Shudhansu Shekhar shudhansu.shekhar.ext@ericsson.com
